### PR TITLE
upToEnd

### DIFF
--- a/src/BaselineOfGToolkitUtility/BaselineOfGToolkitUtility.class.st
+++ b/src/BaselineOfGToolkitUtility/BaselineOfGToolkitUtility.class.st
@@ -17,7 +17,8 @@ BaselineOfGToolkitUtility >> baseline: spec [
 			package: 'GToolkit-Utility-Announcer';
 			package: 'GToolkit-Utility-MessageTally';
 			package: 'GToolkit-Utility-System' with: [
-				spec requires: #( 'GToolkit-Utility-Assertion' ) ]
+				spec requires: #( 'GToolkit-Utility-Assertion' );
+			package: 'GToolkit-Utility-Tests' ]
 	]
 
 ]

--- a/src/GToolkit-Utility-File/ImageReadWriter.extension.st
+++ b/src/GToolkit-Utility-File/ImageReadWriter.extension.st
@@ -3,10 +3,19 @@ Extension { #name : #ImageReadWriter }
 { #category : #'*GToolkit-Utility-File' }
 ImageReadWriter class >> gtFormFromFileReference: aFileReference [
 	<return: #Form>
-	^ aFileReference binaryReadStreamDo: [ :aStream | 
-			| aPositionableReadStream |
-			aPositionableReadStream := ZnPositionableReadStream on: aStream.
-			ImageReadWriter formFromStream: aPositionableReadStream ]
+
+	| stream reader readerClass form fileReference |
+
+	fileReference := aFileReference asFileReference.
+	stream := GtBufferedReadStream on: 
+		(fileReference fileSystem binaryReadStreamOn: fileReference path).
+	form := [
+		readerClass := self readerClassFromStream: stream.
+		reader := readerClass new on: stream.
+		reader nextImage ]
+			ensure: [ stream close ].
+	^ form
+
 ]
 
 { #category : #'*GToolkit-Utility-File' }

--- a/src/GToolkit-Utility-System/GtBufferedReadStream.class.st
+++ b/src/GToolkit-Utility-System/GtBufferedReadStream.class.st
@@ -1,0 +1,52 @@
+"
+GtBufferedReadStream subclasses ZnBufferedReadStream to provide two enhancements:
+
+- #upToEnd is optimised to attempt to retrieve the entire contents in one call.
+  Previously it would retrieve multiple buffers and write them to a WriteStream, resulting in unnecessary copying and garbage.
+- #savingPositionDo: has been added.  ZnBufferedReadStream supports position, so there's no reason to use a ZnPositionableReadStream in this case.
+
+Both of these will be submitted as enhancments to the core system.
+
+
+!!Internal Representation and Key Implementation Points.
+
+No other changes are made to ZnBufferedReadStream, the interface is the same.
+"
+Class {
+	#name : #GtBufferedReadStream,
+	#superclass : #ZnBufferedReadStream,
+	#category : #'GToolkit-Utility-System'
+}
+
+{ #category : #enumerating }
+GtBufferedReadStream >> savingPositionDo: block [
+	"Execute block so that any reading from me in it has no effect afterwards. I remember the current #position and move back to it using #position: after evaluating block. My buffer size limits how long the excursion can be. A SubscriptOutOfBounds exception will be signalled in case this operation cannot be completed."
+	
+	| savedPosition |
+	savedPosition := self position.
+	^ block ensure: [ self position: savedPosition ]
+]
+
+{ #category : #accessing }
+GtBufferedReadStream >> upToEnd [
+	"Read elements until the stream is atEnd and return them as a collection."
+
+	| streamSize result |
+
+	"If the stream knows its size we can reduce overhead by allocating a buffer of the correct size"
+	streamSize := [ self size ]
+		on: Error
+		do: [ 0 ].
+	streamSize > 0 ifTrue:
+		[ result := self next: (streamSize - self position) ].
+	"Some streams may only have an estimate, so if not at the end, get the rest"
+	self atEnd ifFalse:
+		[ result := self collectionSpecies streamContents: [ :out | 
+			result ifNotNil: [ out nextPutAll: result ].
+			[ self atEnd ] whileFalse: [ 
+				position > limit
+					ifTrue: [ self nextBuffer ].	
+				out next: limit - position + 1 putAll: buffer startingAt: position.
+				position := limit + 1 ] ] ].
+	^result
+]

--- a/src/GToolkit-Utility-Tests/GtBufferedReadStreamTests.class.st
+++ b/src/GToolkit-Utility-Tests/GtBufferedReadStreamTests.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #GtBufferedReadStreamTests,
+	#superclass : #ZnBufferedReadStreamTests,
+	#category : #'GToolkit-Utility-Tests'
+}
+
+{ #category : #testing }
+GtBufferedReadStreamTests class >> shouldInheritSelectors [
+
+	^true
+]
+
+{ #category : #tests }
+GtBufferedReadStreamTests >> testSavingPositionDo [
+	| data stream |
+	data := String new: 200 streamContents: [ :out | 
+		200 timesRepeat: [ out nextPut: 'abc' atRandom ] ].
+	stream := GtBufferedReadStream on: data readStream.
+	self deny: stream atEnd.
+	self assert: stream position isZero.
+	stream savingPositionDo: [
+		self assert: stream upToEnd equals: data.
+		self assert: stream atEnd.
+		self assert: stream position equals: 200 ].
+	self deny: stream atEnd.
+	self assert: stream position isZero.
+	self assert: stream upToEnd equals: data.
+	self assert: stream atEnd.
+	self assert: stream position equals: 200
+]

--- a/src/GToolkit-Utility-Tests/package.st
+++ b/src/GToolkit-Utility-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'GToolkit-Utility-Tests' }


### PR DESCRIPTION
Improve file and image reading performance by avoiding multiple buffers.

ZnBufferedReadStream>>upToEnd uses a WriteStream which grows the buffer in steps.  For a 4M file approximately 15 buffers (ByteArray) will be created, copied and discarded.  GtBufferedReadStream modifies #upToEnd so that if the underlying stream knows its size, allocate a buffer of the correct size once and fill it.  The underlying stream is checked to confirm it is at the end in case the size is an under-estimate.  One test on a 4M file showed a 7x speed up in reading the file contents, however this will be highly dependent on many aspects of the environment.

ImageReadWriter class>>gtFormFromFileReference: wrapped the stream with 2 ZnPositionableReadStreams, adding another two layers of buffering.  Remove both ZnPositionableReadStream's as the underlying GtBufferedReadStream can be positioned.

As the image processing time is larger than the file reading time the overall performance improvement is about 20%, although this will of course be dependent on the environment.